### PR TITLE
fix: Extending oninit hook and fixing modal redirection

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -5,7 +5,7 @@ import SettingsPage from 'flarum/components/SettingsPage';
 import LogInModal from 'flarum/components/LogInModal';
 
 app.initializers.add('maicol07-sso', () => {
-  override(LogInModal.prototype, 'init', redirectWhenLoginModalIsOpened);
+  override(LogInModal.prototype, 'oninit', redirectWhenLoginModalIsOpened);
 
   // Remove login button if checkbox is selected
   extend(HeaderSecondary.prototype, 'items', (items) => {


### PR DESCRIPTION
When you setup a Login URL on the extension settings, the button "Start Discussion" still opens a login modal. The expected behavior should be redirect the user to the defined URL.

This PR simply changes the `LogInModal` hook from `init` to `oninit` . 

Flarum version: 0.1.0-beta.14.1