### PR TITLE
chore(locale): Delete Polish translation

### DIFF
--- a/locale/pl.yml
+++ b/locale/pl.yml
@@ -1,7 +1,0 @@
-maicol07-sso:
-    admin:
-        settings:
-            title: "Ustawienia logowania pojedynczego"
-            signup_url: "URL Rejestracji"
-            login_url: "URL Zaloguj"
-            logout_url: "URL Wyloguj"


### PR DESCRIPTION
These translations are outdated and this extension is already translated in Polish language pack: https://github.com/rob006-software/flarum-lang-polish/blob/master/locale/maicol07-sso.yml