### PR TITLE
fix: 🐛 login middleware redirect

### DIFF
--- a/src/Middleware/LoginMiddleware.php
+++ b/src/Middleware/LoginMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Maicol07\SSO\Middleware;
 
+use Flarum\Foundation\Config;
 use Flarum\Http\RequestUtil;
 use Flarum\Http\SessionAccessToken;
 use Flarum\Http\SessionAuthenticator;
@@ -14,6 +15,19 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class LoginMiddleware implements MiddlewareInterface
 {
+     /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @param Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
     final public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $actor = RequestUtil::getActor($request);
@@ -23,7 +37,7 @@ class LoginMiddleware implements MiddlewareInterface
 
         if ($token !== null and $actor->isGuest()) {
             resolve(SessionAuthenticator::class)->logIn($session, $token);
-            return new RedirectResponse($request->getUri());
+            return new RedirectResponse($this->config->url() . $request->getUri()->getPath());
         }
 
         return $handler->handle($request);


### PR DESCRIPTION
Hello,

I found an issue with the login middleware when the forum URL is located in a subpath instead of domain root.

Steps to reproduce:

Flarum location: http://demo.loc/forum

Login with SSO from http://demo.loc

This action will add the following cookie:
flarum_token
** Make sure to not have flarum_session cookie already set

Access http://demo.loc/forum/t/general
You will be redirected to http://demo.loc/t/general

LoginMiddleware.php:40, $request->getUri() returns "http://demo.loc/t/general"