### PR TITLE
feat: ✨ Fix login redirects in embeded mode

### DIFF
--- a/js/src/forum/index.tsx
+++ b/js/src/forum/index.tsx
@@ -40,7 +40,7 @@ app.initializers.add('maicol07-sso', () => {
     if (!setting('provider_mode')) {
       override(LogInModal.prototype, 'oncreate', () => {
         const items = getItems();
-        window.location.href = items.login.url;
+        window.top.location.href = items.login.url;
         throw new Error('Stop execution');
       });
 


### PR DESCRIPTION
Hello,

There's a very useful extension that allows embedding Flarum inside a frame on the main site:
https://github.com/flarum/embed

Since this SSO extension fits perfectly for scenarios that allow merging all the Auth processes, I believe it is a relatively common situation when both extensions are used. The only issue is that guest users when clicking on the Login button (or anything else that triggers a Login popup) are being redirected within a frame, which is not the best solution.

However, that is quite easy to fix by just adding ".top" into the redirect parameter. I've tested and it works properly for both framed and non-framed scenarios.

**Important!** I haven't been able to regenerate the map file, so I would really appreciate if you run the NPM process that would update it and add the result into this branch.

Thank you!