### PR TITLE
fix: do not redirect to `/null` if no `login_url` is set

### DIFF
--- a/js/src/forum/index.tsx
+++ b/js/src/forum/index.tsx
@@ -44,8 +44,13 @@ function getItems(): Record<string, { url: string; itemName: string; removeItem:
 app.initializers.add('maicol07-sso', () => {
   override(LogInModal.prototype, 'oncreate', () => {
     if (!setting('provider_mode', Boolean)) {
-      const items = getItems();
-      window.location.href = items.login.url;
+      const loginUrl = setting('login_url');
+      if (loginUrl) {
+        window.location.href = loginUrl;
+      } else {
+        alert('No SSO login url set, please check the settings!');
+      }
+
       throw new Error('Stop execution');
     }
   });

--- a/js/src/forum/index.tsx
+++ b/js/src/forum/index.tsx
@@ -48,7 +48,7 @@ app.initializers.add('maicol07-sso', () => {
       if (loginUrl) {
         window.location.href = loginUrl;
       } else {
-        alert('No SSO login url set, please check the settings!');
+        app.alerts.show({ type: 'error' }, app.translator.trans('maicol07-sso.forum.no_login_url_error'));
       }
 
       throw new Error('Stop execution');

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -33,3 +33,4 @@ maicol07-sso:
       jwt_signing_algorithm: Signing Method
   forum:
       manage_account_btn: "Manage account"
+      no_login_url_error: "No login URL set, please check the SSO settings!"

--- a/locale/it.yml
+++ b/locale/it.yml
@@ -34,3 +34,4 @@ maicol07-sso:
       jwt_signing_algorithm: Algoritmo firma
   forum:
       manage_account_btn: "Gestisci account"
+      no_login_url_error: "Nessun URL di accesso impostato, controlla le impostazioni SSO!"


### PR DESCRIPTION
fixes https://discuss.flarum.org/d/21666/813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the SSO login URL is missing by displaying an alert and preventing further actions.
  * Enhanced reliability of the login process by directly using the configured login URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->